### PR TITLE
Refactoring changes

### DIFF
--- a/aws/cloudformation/cluster.yml
+++ b/aws/cloudformation/cluster.yml
@@ -25,6 +25,7 @@ Metadata:
           - PublicSubnet1ID
           - PublicSubnet2ID
           - PublicSubnet3ID
+          - BootNodeInstanceType
           - BootNodeAccessCIDR
       - Label:
           default: DNS configuration
@@ -33,9 +34,9 @@ Metadata:
       - Label:
           default: OpenShift hosts configuration
         Parameters:
-          - NumberOfMaster
+          - NumberOfControlPlaneNode
           - NumberOfCompute
-          - MasterInstanceType
+          - ControlPlaneNodeInstanceType
           - ComputeInstanceType
           - ClusterName
           - PrivateCluster
@@ -67,13 +68,15 @@ Metadata:
       NumberOfAZs: 
         default: Number of Availability Zones
       AvailabilityZones:
-        default: Availability Zones  
-      MasterInstanceType:
-        default: Master instance type
+        default: Availability Zones
+      BootNodeInstanceType:
+        default: Boot node instance type
+      ControlPlaneNodeInstanceType:
+        default: ControlPlaneNode instance type
       ComputeInstanceType:
         default: Compute instance type
-      NumberOfMaster:
-        default: Number of master nodes
+      NumberOfControlPlaneNode:
+        default: Number of control plane nodes
       NumberOfCompute:
         default: Number of compute nodes
       DomainName:
@@ -116,6 +119,17 @@ Parameters:
   PublicSubnet3ID:
     Description: The ID of the public subnet in Availability Zone 3 for the ELB load balancer (e.g., subnet-e324ad8e).
     Type: String
+  BootNodeInstanceType:
+    Default: t3.xlarge
+    AllowedValues:
+      - t3.xlarge
+      - t3a.xlarge
+      - m4.xlarge
+      - m5.xlarge
+      - m5a.xlarge
+    ConstraintDescription: Must contain valid instance type
+    Description: The EC2 instance type for the Bootnode that acts as a bastion.
+    Type: String
   BootNodeAccessCIDR:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/x
@@ -135,7 +149,7 @@ Parameters:
   VPCID:
     Description: The ID of your existing VPC for deployment.
     Type: AWS::EC2::VPC::Id
-  MasterInstanceType:
+  ControlPlaneNodeInstanceType:
     Default: m5.xlarge
     AllowedValues:
       - m5.xlarge
@@ -143,7 +157,7 @@ Parameters:
       - m5d.xlarge
       - m5d.2xlarge
     ConstraintDescription: Must contain valid instance type
-    Description: The EC2 instance type for the OpenShift master instances.
+    Description: The EC2 instance type for the OpenShift master/control plane nodes instances.
     Type: String
   ComputeInstanceType:
     Default: m5.large
@@ -158,7 +172,7 @@ Parameters:
   NumberOfAZs:
     Default: 3
     Description: >-
-      The number of Availability Zones to be used for the deployment. Keep in mind that some regions may be limited to two Availability Zones. For a single OCP cluster to be highly available, three Availability Zones are needed to avoid a single point of failure when using three, five, or seven master nodes. With fewer than three Availability Zones, one of the AZs will have more master nodes.
+      The number of Availability Zones to be used for the deployment. Keep in mind that some regions may be limited to two Availability Zones. For a single OCP cluster to be highly available, three Availability Zones are needed to avoid a single point of failure when using three, five, or seven master/control plane nodes. With fewer than three Availability Zones, one of the AZs will have more master/control plane nodes.
     Type: Number
     AllowedValues:
     - 1
@@ -166,9 +180,9 @@ Parameters:
   AvailabilityZones:
     Description: The list of Availability Zones to use for the subnets in the VPC. The Template uses one or three Availability Zones and preserves the logical order you specify.
     Type: List<AWS::EC2::AvailabilityZone::Name>
-  NumberOfMaster:
+  NumberOfControlPlaneNode:
     Default: '3'
-    Description: The desired capacity for the OpenShift master instances. Must be an odd number.A minimum of 3 is required.
+    Description: The desired capacity for the OpenShift master/control plane node instances. Must be an odd number.A minimum of 3 is required.
     Type: String
     AllowedPattern: '^[3579]$|(^[3-9]+[3579]$)'
   NumberOfCompute:
@@ -178,12 +192,13 @@ Parameters:
   DomainName:
     Description: 'Amazon Route53 base domain configured for your OpenShift Container Platform cluster. Name must consist of lower case alphanumeric characters and must start and end with an alphanumeric character.'
     Type: String
-    Default: ""
+    AllowedPattern: '^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$'
+    ConstraintDescription: Must enter a valid Domain Name
   ClusterName:
     Default: ""
     Description: Custom cluster name for kubernetes.io/cluster/tags.
     Type: String
-    AllowedPattern: ^[0-9a-z-]*$
+    AllowedPattern: ^[0-9A-Za-z-]*$
   PrivateCluster:
     Description: To Deploy a Private cluster select true and false for Public cluster
     Type: String
@@ -247,7 +262,7 @@ Rules:
         AssertDescription: All subnets must in the VPC
 
 Conditions:
-  3AZCondition: !Equals [!Ref NumberOfAZs, 3]
+  3AZConditionCheck: !Equals [!Ref NumberOfAZs, '3']
   AcceptLicense: !Equals [!Ref LicenseAgreement, 'I agree']
 
 Resources:
@@ -407,9 +422,10 @@ Resources:
             /home/ec2-user/destroy.sh:
               content: |
                 echo "$1 - Destroy"
-                cd /home/ec2-user/zmodstack/terraform
+                cd /home/ec2-user/zmodstack/aws/terraform
                 sudo terraform destroy --var-file=terraform.tfvars --auto-approve | tee terraform_destroy.log
                 aws ssm put-parameter --name $1"_CleanupStatus" --type "String" --value "READY" --overwrite
+              mode: '000777'
             /root/.aws/config:
               content: !Sub |
                 [default]
@@ -439,7 +455,7 @@ Resources:
             !Sub
             - "${ClusterName}-bootnode"
             - ClusterName: !Ref ClusterName
-      InstanceType: t3.xlarge
+      InstanceType: !Ref BootNodeInstanceType
       NetworkInterfaces:
       - GroupSet:
         - !Ref BootnodeSecurityGroup
@@ -461,10 +477,9 @@ Resources:
 
             # Add /usr/local/bin to global PATH
             echo "export PATH=$PATH:/usr/local/bin" >> /etc/bashrc
-
             # Install basic yum pre-reqs
             yum update -y
-            yum install -y git wget python38 yum-utils httpd-tools unzip
+            yum install -y git wget python38 yum-utils httpd-tools unzip gcc
 
             # Install AWS v2 CLI
             curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
@@ -478,14 +493,22 @@ Resources:
             systemctl start amazon-ssm-agent
             systemctl enable amazon-ssm-agent
             rm -f ./amazon-ssm-agent.rpm
-            
-            # Clone git repo containing automation scripts
-            git clone https://github.com/IBM/zmodstack-deploy.git /home/ec2-user/zmodstack
+
+            # Tagging the root ebs volume
+            AWS_AVAIL_ZONE=$(curl http://169.254.169.254/latest/meta-data/placement/availability-zone)
+            AWS_REGION="`echo \"$AWS_AVAIL_ZONE\" | sed 's/[a-z]$//'`"
+            AWS_INSTANCE_ID=$(curl http://169.254.169.254/latest/meta-data/instance-id)
+            ROOT_VOLUME_IDS=$(aws ec2 describe-instances --region $AWS_REGION --instance-id $AWS_INSTANCE_ID --output text --query Reservations[0].Instances[0].BlockDeviceMappings[0].Ebs.VolumeId)
+            aws ec2 create-tags --resources $ROOT_VOLUME_IDS --region $AWS_REGION --tags Key=Name,Value=\"${AWS::StackName}-bootnode-volume\"           
+ 
+            # Clone git repo containing automation scripts for AWS
+            git clone --no-checkout https://github.com/IBM/zmodstack-deploy.git /home/ec2-user/zmodstack
+            cd zmodstack && git sparse-checkout set aws && git checkout @
             chown -fR ec2-user:ec2-user /home/ec2-user/zmodstack
-            source /home/ec2-user/zmodstack/scripts/bootnode-bootstrap.sh
+            source /home/ec2-user/zmodstack/aws/scripts/bootstrap.sh
 
             # Begin Terraform execution
-            cd /home/ec2-user/zmodstack/terraform
+            cd /home/ec2-user/zmodstack/aws/terraform
             aws s3 cp s3://${S3BucketName}/zmodstack/ocp/pull-secret.json ./pull-secret
             
             echo "Creating terraform variables file"
@@ -506,48 +529,55 @@ Resources:
             echo "accept_license=\"${LicenseAgreement}\"" >> terraform.tfvars
             echo "new_or_existing_vpc_subnet=\"exist\"" >> terraform.tfvars
             echo "vpc_id=\"${VPCID}\"" >> terraform.tfvars
-            echo "master_subnet1_id=\"${PublicSubnet1ID}\"" >> terraform.tfvars
-            echo "master_subnet2_id=\"${PublicSubnet2ID}\"" >> terraform.tfvars
-            echo "master_subnet3_id=\"${PublicSubnet3ID}\"" >> terraform.tfvars
-            echo "worker_subnet1_id=\"${PrivateSubnet1ID}\"" >> terraform.tfvars
-            echo "worker_subnet2_id=\"${PrivateSubnet2ID}\"" >> terraform.tfvars
-            echo "worker_subnet3_id=\"${PrivateSubnet3ID}\"" >> terraform.tfvars
+            echo "control_plane_node_subnet1_id=\"${PublicSubnet1ID}\"" >> terraform.tfvars
+            echo "control_plane_node_subnet2_id=\"${PublicSubnet2ID}\"" >> terraform.tfvars
+            echo "control_plane_node_subnet3_id=\"${PublicSubnet3ID}\"" >> terraform.tfvars
+            echo "computenode_subnet1_id=\"${PrivateSubnet1ID}\"" >> terraform.tfvars
+            echo "computenode_subnet2_id=\"${PrivateSubnet2ID}\"" >> terraform.tfvars
+            echo "computenode_subnet3_id=\"${PrivateSubnet3ID}\"" >> terraform.tfvars
             echo "vpc_cidr=\"${VPCCIDR}\"" >> terraform.tfvars
             echo "availability_zone1=\"${AvailabilityZone1}\"" >> terraform.tfvars
             echo "availability_zone2=\"${AvailabilityZone2}\"" >> terraform.tfvars
             echo "availability_zone3=\"${AvailabilityZone3}\"" >> terraform.tfvars
-            echo "master_instance_type=\"${MasterInstanceType}\"" >> terraform.tfvars
-            echo "master_replica_count=${NumberOfMaster}" >> terraform.tfvars
-            echo "worker_instance_type=\"${ComputeInstanceType}\"" >> terraform.tfvars
-            echo "worker_replica_count=${NumberOfCompute}" >> terraform.tfvars
+            echo "control_plane_node_instance_type=\"${ControlPlaneNodeInstanceType}\"" >> terraform.tfvars
+            echo "control_plane_node_replica_count=${NumberOfControlPlaneNode}" >> terraform.tfvars
+            echo "computenode_instance_type=\"${ComputeInstanceType}\"" >> terraform.tfvars
+            echo "computenode_replica_count=${NumberOfCompute}" >> terraform.tfvars
             echo "enable_permission_quota_check=\"false\"" >> terraform.tfvars
 
             export TF_LOG=DEBUG
-            export TF_LOG_PATH=/home/ec2-user/zmodstack/terraform/tf-trace.log
+            export TF_LOG_PATH=/home/ec2-user/zmodstack/aws/terraform/tf-trace.log
             terraform init -input=false
             terraform plan -out=tfplan -input=false
             terraform apply -input=false tfplan
 
             # Retreieve terraform exit code
             ecode=$?
+            
+            # Setup kubeconfig for ec2-user
+            mkdir -p /home/ec2-user/.kube/
+            cp /home/ec2-user/zmodstack/aws/terraform/installer-files/auth/kubeconfig /home/ec2-user/.kube/
+            mv /home/ec2-user/.kube/kubeconfig /home/ec2-user/.kube/config
+            export KUBECONFIG=$KUBECONFIG:/home/ec2-user/.kube/config
+            echo 'export KUBECONFIG=$KUBECONFIG:/home/ec2-user/.kube/config' >> ~/.bash_profile
+            chown -R ec2-user:ec2-user /home/ec2-user/.kube
 
             # Copy values logs to S3
             aws s3 cp /var/log/cloud-init-output.log s3://${S3BucketName}/zmodstack/logs/${AWS::StackName}_cloud-init-output.log
-            aws s3 cp /home/ec2-user/zmodstack/terraform/tf-trace.log s3://${S3BucketName}/zmodstack/logs/${AWS::StackName}_tf-trace.log
-            aws s3 cp /home/ec2-user/zmodstack/terraform/terraform.tfstate s3://${S3BucketName}/zmodstack/logs/${AWS::StackName}_terraform.tfstate
-
-            cp -rf ~/.kube/ /home/ec2-user/
-            chown -R ec2-user:ec2-user /home/ec2-user/.kube
-            oc exec -it $(oc get pod -l component=usermgmt | tail -1 | cut -f1 -d\ ) -- bash -c "printf \"${OpenshiftPassword}\n\" | /usr/src/server-src/scripts/manage-user.sh --enable-user admin"
+            aws s3 cp /home/ec2-user/zmodstack/aws/terraform/tf-trace.log s3://${S3BucketName}/zmodstack/logs/${AWS::StackName}_tf-trace.log
+            aws s3 cp /home/ec2-user/zmodstack/aws/terraform/terraform.tfstate s3://${S3BucketName}/zmodstack/logs/${AWS::StackName}_terraform.tfstate
+            
+            # send completion signal
+            ln -s /aws-cfn-bootstrap-2.0/cfnbootstrap /usr/lib/python3.8/site-packages/cfnbootstrap
             cfn-signal --exit-code $ecode --id $AWS_STACKID  --data "See logs at ${S3BucketName}" $InstallCompleteURL
           -
             IAMUserAccessKey: !Ref IAMUserAccessKey
             IAMUserSecret: !GetAtt [IAMUserAccessKey, SecretAccessKey]
             LicenseAgreement: !If [ AcceptLicense, 'accept', 'reject']
-            AZ: !If [ 3AZCondition , 'multi_zone', 'single_zone']
+            AZ: !If [ 3AZConditionCheck, 'multi_zone', 'single_zone']
             AvailabilityZone1: !Select [0, !Ref AvailabilityZones]
-            AvailabilityZone2: !If [ 3AZCondition, !Select [1, !Ref AvailabilityZones], ""]
-            AvailabilityZone3: !If [ 3AZCondition, !Select [2, !Ref AvailabilityZones], ""]
+            AvailabilityZone2: !If [ 3AZConditionCheck, !Select [1, !Ref AvailabilityZones], ""]
+            AvailabilityZone3: !If [ 3AZConditionCheck, !Select [2, !Ref AvailabilityZones], ""]
   
   CleanUpLambda:
     Type: AWS::Lambda::Function

--- a/aws/cloudformation/cluster.yml
+++ b/aws/cloudformation/cluster.yml
@@ -355,6 +355,9 @@ Resources:
             Action: "ec2:DetachVolume"
             Resource: "*"
           - Effect: "Allow"
+            Action: "ec2:CreateTags"
+            Resource: "*"
+          - Effect: "Allow"
             Action:
             - "secretsmanager:GetSecretValue"
             - "secretsmanager:UpdateSecret"
@@ -479,7 +482,7 @@ Resources:
             echo "export PATH=$PATH:/usr/local/bin" >> /etc/bashrc
             # Install basic yum pre-reqs
             yum update -y
-            yum install -y git wget python38 yum-utils httpd-tools unzip gcc
+            yum install -y git wget python38 yum-utils httpd-tools unzip
 
             # Install AWS v2 CLI
             curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
@@ -503,9 +506,9 @@ Resources:
  
             # Clone git repo containing automation scripts for AWS
             git clone --no-checkout https://github.com/IBM/zmodstack-deploy.git /home/ec2-user/zmodstack
-            cd zmodstack && git sparse-checkout set aws && git checkout @
+            cd /home/ec2-user/zmodstack && git sparse-checkout set aws && git checkout @
             chown -fR ec2-user:ec2-user /home/ec2-user/zmodstack
-            source /home/ec2-user/zmodstack/aws/scripts/bootstrap.sh
+            source /home/ec2-user/zmodstack/aws/scripts/bootnode-bootstrap.sh
 
             # Begin Terraform execution
             cd /home/ec2-user/zmodstack/aws/terraform

--- a/aws/cloudformation/main.yml
+++ b/aws/cloudformation/main.yml
@@ -23,8 +23,8 @@ Metadata:
           - OpenshiftVersion
           - OpenshiftUsername
           - OpenshiftPassword
-          - NumberOfMaster
-          - MasterInstanceType
+          - NumberOfControlPlaneNode
+          - ControlPlaneNodeInstanceType
           - NumberOfCompute
           - ComputeInstanceType
       - Label:
@@ -39,6 +39,7 @@ Metadata:
           - PublicSubnet1CIDR
           - PublicSubnet2CIDR
           - PublicSubnet3CIDR
+          - BootNodeInstanceType
           - BootNodeAccessCIDR
 
     ParameterLabels:
@@ -54,18 +55,20 @@ Metadata:
         default: Public subnet 2 CIDR
       PublicSubnet3CIDR:
         default: Public subnet 3 CIDR
+      BootNodeInstanceType:
+        default: Boot node instance type
       BootNodeAccessCIDR:
         default: Boot node external access CIDR
       VPCCIDR:
         default: Virtual Private Cloud CIDR
       S3BucketName:
         default: S3 bucket name
-      MasterInstanceType:
-        default: Master node instance type
+      ControlPlaneNodeInstanceType:
+        default: Control Plane node instance type
       ComputeInstanceType:
         default: Compute node instance type
-      NumberOfMaster:
-        default: Number of master nodes
+      NumberOfControlPlaneNode:
+        default: Number of Control Plane nodes
       NumberOfCompute:
         default: Number of compute nodes
       DomainName:
@@ -88,7 +91,7 @@ Metadata:
 Parameters:
   NumberOfAZs:
     Description: >-
-      The number of Availability Zones to be used for the deployment. Keep in mind that some regions may be limited to 2 Availability Zones. For a single OCP cluster to be highly available, 3 Availability Zones are needed to avoid a single point of failure when using 3, 5 or 7 master nodes.  With less than 3 Availability Zones, one of the AZs will have more master nodes.
+      The number of Availability Zones to be used for the deployment. Keep in mind that some regions may be limited to 2 Availability Zones. For a single OCP cluster to be highly available, 3 Availability Zones are needed to avoid a single point of failure when using 3, 5 or 7 control plane nodes.  With less than 3 Availability Zones, one of the AZs will have more control plane nodes.
     Type: Number
     Default: 3
     AllowedValues:
@@ -134,6 +137,17 @@ Parameters:
     Default: 10.0.160.0/20
     Description: The CIDR block for the public subnet located in Availability Zone 3.
     Type: String
+  BootNodeInstanceType:
+    Default: t3.xlarge
+    AllowedValues:
+      - t3.xlarge
+      - t3a.xlarge
+      - m4.xlarge
+      - m5.xlarge
+      - m5a.xlarge
+    ConstraintDescription: Must contain valid instance type
+    Description: The EC2 Instance type for the bootnode instance that acts as a bastion. 
+    Type: String
   BootNodeAccessCIDR:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/x
@@ -150,13 +164,13 @@ Parameters:
     Default: 10.0.0.0/16
     Description: The CIDR block that will be associated to the newly created AWS VPC. This CIDR block SHOULD NOT conflict with existing VPCs in the selected AWS Region. 
     Type: String
-  MasterInstanceType:
+  ControlPlaneNodeInstanceType:
     Default: m5.xlarge
     AllowedValues:
       - m5.xlarge
       - m5.2xlarge
     ConstraintDescription: Must contain valid instance type
-    Description: The EC2 instance type for the OpenShift master instances.
+    Description: The EC2 instance type for the OpenShift control plane instances.
     Type: String
   ComputeInstanceType:
     Default: m5.xlarge
@@ -168,9 +182,9 @@ Parameters:
     ConstraintDescription: Must contain valid instance type
     Description: The EC2 instance type for the OpenShift compute instances.
     Type: String
-  NumberOfMaster:
+  NumberOfControlPlaneNode:
     Default: '3'
-    Description: The desired capacity for the OpenShift master instances. Must be an odd number. A minimum of 3 is required.
+    Description: The desired capacity for the OpenShift control plane instances. Must be an odd number. A minimum of 3 is required.
     Type: String
     AllowedPattern: '^[3579]$|(^[3-9]+[3579]$)'
   NumberOfCompute:
@@ -180,14 +194,17 @@ Parameters:
   DomainName:
     Description: The FQDN of an Amazon Route 53 registered domain and/or hosted zone. A Route 53 subdomain DNS record will be registed for proper routing to the created OpenShift cluster. Reference the Deployment Guide for more details.
     Type: String
+    AllowedPattern: '^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$'
+    ConstraintDescription: Must enter a valid Domain Name
   OpenshiftVersion:
     Description: The OpenShift version that should be deployed. The latest stable version of the selected version will be deployed. 
     Type: String
-    Default: "4.10"
+    Default: "4.11"
     AllowedValues:
       - "4.9"
       - "4.10"
       - "4.11"
+      - "4.12"
   OpenshiftUsername:
     Description: The OpenShift username that will be created as the default cluster-admin. This username will be used to login to the OpenShift Console.
     Type: String
@@ -219,6 +236,7 @@ Rules:
       AssertDescription: User must agree to the terms of the license agreement.
 
 Conditions:
+  3AZConditionCheck: !Equals [!Ref NumberOfAZs, '3']
   3AZSelectionCondition:
     Fn::Equals:
     - Fn::Length:
@@ -230,10 +248,10 @@ Conditions:
         Ref: AvailabilityZones
     - 1
   3AZCondition: !And 
-    - !Equals [!Ref NumberOfAZs, 3]
+    - !Equals [!Ref NumberOfAZs, '3']
     - !Condition 3AZSelectionCondition
   1AZCondition: !And 
-    - !Equals [!Ref NumberOfAZs, 1]
+    - !Equals [!Ref NumberOfAZs, '1']
     - !Condition 1AZSelectionCondition
   AZValidation: !Or 
     - !Condition 1AZCondition
@@ -283,28 +301,17 @@ Resources:
       Parameters:
         NumberOfAZs: !Ref NumberOfAZs
         AvailabilityZones: !Join [ ',', !Ref 'AvailabilityZones']
-        MasterInstanceType: !Ref 'MasterInstanceType'
+        BootNodeInstanceType: !Ref 'BootNodeInstanceType'
+        ControlPlaneNodeInstanceType: !Ref 'ControlPlaneNodeInstanceType'
         ComputeInstanceType: !Ref 'ComputeInstanceType'
-        NumberOfMaster: !Ref 'NumberOfMaster'
+        NumberOfControlPlaneNode: !Ref 'NumberOfControlPlaneNode'
         NumberOfCompute: !Ref 'NumberOfCompute'
         PrivateSubnet1ID: !GetAtt 'VPCStack.Outputs.PrivateSubnet1AID'
-        PrivateSubnet2ID: !If
-          - 3AZCondition
-          - !GetAtt 'VPCStack.Outputs.PrivateSubnet2AID'
-          - ""
-        PrivateSubnet3ID: !If
-          - 3AZCondition
-          - !GetAtt 'VPCStack.Outputs.PrivateSubnet3AID'
-          - ""
+        PrivateSubnet2ID: !If [3AZConditionCheck, !GetAtt 'VPCStack.Outputs.PrivateSubnet2AID', ""]
+        PrivateSubnet3ID: !If [3AZConditionCheck, !GetAtt 'VPCStack.Outputs.PrivateSubnet3AID', ""]
         PublicSubnet1ID: !GetAtt 'VPCStack.Outputs.PublicSubnet1ID'
-        PublicSubnet2ID: !If
-          - 3AZCondition
-          - !GetAtt 'VPCStack.Outputs.PublicSubnet2ID'
-          - ""
-        PublicSubnet3ID: !If
-          - 3AZCondition
-          - !GetAtt 'VPCStack.Outputs.PublicSubnet3ID'
-          - ""
+        PublicSubnet2ID: !If [3AZConditionCheck, !GetAtt 'VPCStack.Outputs.PublicSubnet2ID', ""]
+        PublicSubnet3ID: !If [3AZConditionCheck, !GetAtt 'VPCStack.Outputs.PublicSubnet3ID', ""]
         BootNodeAccessCIDR: !Ref 'BootNodeAccessCIDR'
         S3BucketName: !Ref S3BucketName
         VPCCIDR: !Ref 'VPCCIDR'

--- a/aws/cloudformation/vpc.yml
+++ b/aws/cloudformation/vpc.yml
@@ -107,12 +107,12 @@ Parameters:
     Type: String
   NumberOfAZs:
     AllowedValues:
-    - '1'
-    - '3'
-    Default: '1'
+    - 1
+    - 3
+    Default: 1
     Description: Number of Availability Zones to use in the VPC. This must match your
       selections in the list of Availability Zones parameter.
-    Type: String
+    Type: Number
   PrivateSubnet1ACIDR:
     AllowedPattern: "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/(1[6-9]|2[0-8]))$"
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
@@ -789,7 +789,7 @@ Resources:
         - Ref: AWS::NoValue
       MapPublicIpOnLaunch: true
   PublicSubnet2:
-    Condition: PrivateSubnets&3AZCondition
+    Condition: 3AZCondition
     Type: AWS::EC2::Subnet
     Properties:
       VpcId:
@@ -1332,6 +1332,11 @@ Resources:
       VpcId:
         Ref: VPC
 Outputs:
+  NumberOfAZ:
+    Condition: 3AZCondition
+    Description: Number of AZ
+    Value:
+      Ref: NumberOfAZs
   NAT1EIP:
     Condition: PrivateSubnetsCondition
     Description: NAT 1 IP address
@@ -1476,6 +1481,7 @@ Outputs:
         Fn::Sub: "${AWS::StackName}-PublicSubnet2CIDR"
   PublicSubnet2ID:
     Condition: 3AZCondition
+#    Condition: PrivateSubnets&3AZCondition
     Description: Public subnet 2 ID in Availability Zone 2
     Value:
       Ref: PublicSubnet2

--- a/aws/scripts/bootnode-bootstrap.sh
+++ b/aws/scripts/bootnode-bootstrap.sh
@@ -29,6 +29,8 @@ wget https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-late
 tar -xzf aws-cfn-bootstrap-py3-latest.tar.gz
 cd aws-cfn-bootstrap-2.0 || return
 python3 setup.py install &> /var/log/userdata.cfn-bootstrap-setup.log
+# Add /usr/local/bin to global PATH
+echo "export PATH=$PATH:/usr/local/bin" >> /etc/bashrc
 
 # Trigger the cfn-init helper script to handle the AWS::CloudFormation::Init directive
 cfn-init -v --stack "${AWS_STACKNAME}" --resource BootnodeInstance --configsets Required --region "${AWS_REGION}"

--- a/aws/scripts/cluster-shutdown.sh
+++ b/aws/scripts/cluster-shutdown.sh
@@ -1,0 +1,8 @@
+#list all nodes
+oc get nodes --kubeconfig /home/ec2-user/.kube/config
+​
+#check for certs expiry
+oc -n openshift-kube-apiserver-operator get secret kube-apiserver-to-kubelet-signer -o jsonpath='{.metadata.annotations.auth\.openshift\.io/certificate-not-after}' --kubeconfig /home/ec2-user/.kube/config
+​
+#shutdown
+for node in $(oc get nodes --kubeconfig /home/ec2-user/.kube/config -o jsonpath='{.items[*].metadata.name}'); do oc debug node/${node} --kubeconfig /home/ec2-user/.kube/config -- chroot /host shutdown -h 1; done

--- a/aws/terraform/main.tf
+++ b/aws/terraform/main.tf
@@ -13,24 +13,24 @@ provider "aws" {
 data "aws_availability_zones" "azs" {}
 
 locals {
-  installer_workspace = "${path.root}/installer-files"
-  availability_zone1  = var.availability_zone1 == "" ? data.aws_availability_zones.azs.names[0] : var.availability_zone1
-  availability_zone2  = var.az == "multi_zone" && var.availability_zone2 == "" ? data.aws_availability_zones.azs.names[1] : var.availability_zone2
-  availability_zone3  = var.az == "multi_zone" && var.availability_zone3 == "" ? data.aws_availability_zones.azs.names[2] : var.availability_zone3
-  vpc_id              = var.new_or_existing_vpc_subnet == "new" ? module.network[0].vpcid : var.vpc_id
-  master_subnet1_id   = var.new_or_existing_vpc_subnet == "new" ? module.network[0].master_subnet1_id : var.master_subnet1_id
-  master_subnet2_id   = var.new_or_existing_vpc_subnet == "new" && var.az == "multi_zone" ? module.network[0].master_subnet2_id[0] : var.master_subnet2_id
-  master_subnet3_id   = var.new_or_existing_vpc_subnet == "new" && var.az == "multi_zone" ? module.network[0].master_subnet3_id[0] : var.master_subnet3_id
-  worker_subnet1_id   = var.new_or_existing_vpc_subnet == "new" ? module.network[0].worker_subnet1_id : var.worker_subnet1_id
-  worker_subnet2_id   = var.new_or_existing_vpc_subnet == "new" && var.az == "multi_zone" ? module.network[0].worker_subnet2_id[0] : var.worker_subnet2_id
-  worker_subnet3_id   = var.new_or_existing_vpc_subnet == "new" && var.az == "multi_zone" ? module.network[0].worker_subnet3_id[0] : var.worker_subnet3_id
-  single_zone_subnets = [local.worker_subnet1_id]
-  multi_zone_subnets  = [local.worker_subnet1_id, local.worker_subnet2_id, local.worker_subnet3_id]
-  openshift_api       = var.existing_cluster ? var.existing_openshift_api : module.ocp[0].openshift_api
-  openshift_username  = var.existing_cluster ? var.existing_openshift_username : module.ocp[0].openshift_username
-  openshift_password  = var.existing_cluster ? var.existing_openshift_password : module.ocp[0].openshift_password
-  openshift_token     = var.existing_openshift_token
-  cluster_type        = "selfmanaged"
+  installer_workspace             = "${path.root}/aws/installer-files"
+  availability_zone1              = var.availability_zone1 == "" ? data.aws_availability_zones.azs.names[0] : var.availability_zone1
+  availability_zone2              = var.az == "multi_zone" && var.availability_zone2 == "" ? data.aws_availability_zones.azs.names[1] : var.availability_zone2
+  availability_zone3              = var.az == "multi_zone" && var.availability_zone3 == "" ? data.aws_availability_zones.azs.names[2] : var.availability_zone3
+  vpc_id                          = var.new_or_existing_vpc_subnet == "new" ? module.network[0].vpcid : var.vpc_id
+  control_plane_node_subnet1_id   = var.new_or_existing_vpc_subnet == "new" ? module.network[0].control_plane_node_subnet1_id : var.control_plane_node_subnet1_id
+  control_plane_node_subnet2_id   = var.new_or_existing_vpc_subnet == "new" && var.az == "multi_zone" ? module.network[0].control_plane_node_subnet2_id[0] : var.control_plane_node_subnet2_id
+  control_plane_node_subnet3_id   = var.new_or_existing_vpc_subnet == "new" && var.az == "multi_zone" ? module.network[0].control_plane_node_subnet3_id[0] : var.control_plane_node_subnet3_id
+  computenode_subnet1_id          = var.new_or_existing_vpc_subnet == "new" ? module.network[0].computenode_subnet1_id : var.computenode_subnet1_id
+  computenode_subnet2_id          = var.new_or_existing_vpc_subnet == "new" && var.az == "multi_zone" ? module.network[0].computenode_subnet2_id[0] : var.computenode_subnet2_id
+  computenode_subnet3_id          = var.new_or_existing_vpc_subnet == "new" && var.az == "multi_zone" ? module.network[0].computenode_subnet3_id[0] : var.computenode_subnet3_id
+  single_zone_subnets             = [local.computenode_subnet1_id]
+  multi_zone_subnets              = [local.computenode_subnet1_id, local.computenode_subnet2_id, local.computenode_subnet3_id]
+  openshift_api                   = var.existing_cluster ? var.existing_openshift_api : module.ocp[0].openshift_api
+  openshift_username              = var.existing_cluster ? var.existing_openshift_username : module.ocp[0].openshift_username
+  openshift_password              = var.existing_cluster ? var.existing_openshift_password : module.ocp[0].openshift_password
+  openshift_token                 = var.existing_openshift_token
+  cluster_type                    = "selfmanaged"
 }
 
 resource "null_resource" "aws_configuration" {
@@ -76,21 +76,21 @@ resource "null_resource" "permission_resource_validation" {
 }
 
 module "network" {
-  count               = var.new_or_existing_vpc_subnet == "new" && var.existing_cluster == false ? 1 : 0
-  source              = "./network"
-  vpc_cidr            = var.vpc_cidr
-  network_tag_prefix  = var.cluster_name
-  tenancy             = var.tenancy
-  master_subnet_cidr1 = var.master_subnet_cidr1
-  master_subnet_cidr2 = var.master_subnet_cidr2
-  master_subnet_cidr3 = var.master_subnet_cidr3
-  worker_subnet_cidr1 = var.worker_subnet_cidr1
-  worker_subnet_cidr2 = var.worker_subnet_cidr2
-  worker_subnet_cidr3 = var.worker_subnet_cidr3
-  az                  = var.az
-  availability_zone1  = local.availability_zone1
-  availability_zone2  = local.availability_zone2
-  availability_zone3  = local.availability_zone3
+  count                           = var.new_or_existing_vpc_subnet == "new" && var.existing_cluster == false ? 1 : 0
+  source                          = "./network"
+  vpc_cidr                        = var.vpc_cidr
+  network_tag_prefix              = var.cluster_name
+  tenancy                         = var.tenancy
+  control_plane_node_subnet_cidr1 = var.control_plane_node_subnet_cidr1
+  control_plane_node_subnet_cidr2 = var.control_plane_node_subnet_cidr2
+  control_plane_node_subnet_cidr3 = var.control_plane_node_subnet_cidr3
+  computenode_subnet_cidr1        = var.computenode_subnet_cidr1
+  computenode_subnet_cidr2        = var.computenode_subnet_cidr2
+  computenode_subnet_cidr3        = var.computenode_subnet_cidr3
+  az                              = var.az
+  availability_zone1              = local.availability_zone1
+  availability_zone2              = local.availability_zone2
+  availability_zone3              = local.availability_zone3
 
   depends_on = [
     null_resource.aws_configuration,
@@ -99,49 +99,47 @@ module "network" {
 }
 
 module "ocp" {
-  count                           = var.existing_cluster ? 0 : 1
-  source                          = "./ocp"
-  openshift_installer_url         = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp"
-  multi_zone                      = var.az == "multi_zone" ? true : false
-  cluster_name                    = var.cluster_name
-  base_domain                     = var.base_domain
-  region                          = var.region
-  availability_zone1              = local.availability_zone1
-  availability_zone2              = local.availability_zone2
-  availability_zone3              = local.availability_zone3
-  worker_instance_type            = var.worker_instance_type
-  worker_instance_volume_iops     = var.worker_instance_volume_iops
-  worker_instance_volume_type     = var.worker_instance_volume_type
-  worker_instance_volume_size     = var.worker_instance_volume_size
-  worker_replica_count            = var.worker_replica_count
-  master_instance_type            = var.master_instance_type
-  master_instance_volume_iops     = var.master_instance_volume_iops
-  master_instance_volume_type     = var.master_instance_volume_type
-  master_instance_volume_size     = var.master_instance_volume_size
-  master_replica_count            = var.master_replica_count
-  cluster_network_cidr            = var.cluster_network_cidr
-  cluster_network_host_prefix     = var.cluster_network_host_prefix
-  machine_network_cidr            = var.vpc_cidr
-  service_network_cidr            = var.service_network_cidr
-  master_subnet1_id               = local.master_subnet1_id
-  master_subnet2_id               = local.master_subnet2_id
-  master_subnet3_id               = local.master_subnet3_id
-  worker_subnet1_id               = local.worker_subnet1_id
-  worker_subnet2_id               = local.worker_subnet2_id
-  worker_subnet3_id               = local.worker_subnet3_id
-  private_cluster                 = var.private_cluster
-  openshift_pull_secret_file_path = var.openshift_pull_secret_file_path
-  public_ssh_key                  = var.public_ssh_key
-  enable_fips                     = var.enable_fips
-  openshift_username              = var.openshift_username
-  openshift_password              = var.openshift_password
-  enable_autoscaler               = var.enable_autoscaler
-  installer_workspace             = local.installer_workspace
-  openshift_version               = var.openshift_version
-  vpc_id                          = local.vpc_id
-  external_registry               = var.external_registry
-  external_registry_username      = var.external_registry_username
-  external_registry_password      = var.external_registry_password
+  count                                       = var.existing_cluster ? 0 : 1
+  source                                      = "./ocp"
+  openshift_installer_url                     = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp"
+  multi_zone                                  = var.az == "multi_zone" ? true : false
+  cluster_name                                = var.cluster_name
+  base_domain                                 = var.base_domain
+  region                                      = var.region
+  availability_zone1                          = local.availability_zone1
+  availability_zone2                          = local.availability_zone2
+  availability_zone3                          = local.availability_zone3
+  computenode_instance_type                   = var.computenode_instance_type
+  computenode_instance_volume_type            = var.computenode_instance_volume_type
+  computenode_instance_volume_size            = var.computenode_instance_volume_size
+  computenode_replica_count                   = var.computenode_replica_count
+  control_plane_node_instance_type            = var.control_plane_node_instance_type
+  control_plane_node_instance_volume_type     = var.control_plane_node_instance_volume_type
+  control_plane_node_instance_volume_size     = var.control_plane_node_instance_volume_size
+  control_plane_node_replica_count            = var.control_plane_node_replica_count
+  cluster_network_cidr                        = var.cluster_network_cidr
+  cluster_network_host_prefix                 = var.cluster_network_host_prefix
+  machine_network_cidr                        = var.vpc_cidr
+  service_network_cidr                        = var.service_network_cidr
+  control_plane_node_subnet1_id               = local.control_plane_node_subnet1_id
+  control_plane_node_subnet2_id               = local.control_plane_node_subnet2_id
+  control_plane_node_subnet3_id               = local.control_plane_node_subnet3_id
+  computenode_subnet1_id                      = local.computenode_subnet1_id
+  computenode_subnet2_id                      = local.computenode_subnet2_id
+  computenode_subnet3_id                      = local.computenode_subnet3_id
+  private_cluster                             = var.private_cluster
+  openshift_pull_secret_file_path             = var.openshift_pull_secret_file_path
+  public_ssh_key                              = var.public_ssh_key
+  enable_fips                                 = var.enable_fips
+  openshift_username                          = var.openshift_username
+  openshift_password                          = var.openshift_password
+  enable_autoscaler                           = var.enable_autoscaler
+  installer_workspace                         = local.installer_workspace
+  openshift_version                           = var.openshift_version
+  vpc_id                                      = local.vpc_id
+  external_registry                           = var.external_registry
+  external_registry_username                  = var.external_registry_username
+  external_registry_password                  = var.external_registry_password
 
   depends_on = [
     module.network,

--- a/aws/terraform/main.tf
+++ b/aws/terraform/main.tf
@@ -13,7 +13,7 @@ provider "aws" {
 data "aws_availability_zones" "azs" {}
 
 locals {
-  installer_workspace             = "${path.root}/aws/installer-files"
+  installer_workspace             = "${path.root}/installer-files"
   availability_zone1              = var.availability_zone1 == "" ? data.aws_availability_zones.azs.names[0] : var.availability_zone1
   availability_zone2              = var.az == "multi_zone" && var.availability_zone2 == "" ? data.aws_availability_zones.azs.names[1] : var.availability_zone2
   availability_zone3              = var.az == "multi_zone" && var.availability_zone3 == "" ? data.aws_availability_zones.azs.names[2] : var.availability_zone3

--- a/aws/terraform/network/main.tf
+++ b/aws/terraform/network/main.tf
@@ -8,67 +8,67 @@ resource "aws_vpc" "vpc" {
   }
 }
 
-resource "aws_internet_gateway" "master" {
+resource "aws_internet_gateway" "control_plane_node" {
   vpc_id = aws_vpc.vpc.id
 }
 
-resource "aws_subnet" "master1" {
+resource "aws_subnet" "control_plane_node1" {
   vpc_id                  = aws_vpc.vpc.id
-  cidr_block              = var.master_subnet_cidr1
+  cidr_block              = var.control_plane_node_subnet_cidr1
   availability_zone       = var.availability_zone1
   map_public_ip_on_launch = true
-  depends_on              = [aws_internet_gateway.master]
+  depends_on              = [aws_internet_gateway.control_plane_node]
 
   tags = {
     "Name" : join("-", [var.network_tag_prefix, "public-subnet", var.availability_zone1])
   }
 }
-resource "aws_subnet" "master2" {
+resource "aws_subnet" "control_plane_node2" {
   count                   = var.az == "multi_zone" ? 1 : 0
   vpc_id                  = aws_vpc.vpc.id
-  cidr_block              = var.master_subnet_cidr2
+  cidr_block              = var.control_plane_node_subnet_cidr2
   availability_zone       = var.availability_zone2
   map_public_ip_on_launch = true
-  depends_on              = [aws_internet_gateway.master]
+  depends_on              = [aws_internet_gateway.control_plane_node]
 
   tags = {
     "Name" : join("-", [var.network_tag_prefix, "public-subnet", var.availability_zone2])
   }
 }
-resource "aws_subnet" "master3" {
+resource "aws_subnet" "control_plane_node3" {
   count                   = var.az == "multi_zone" ? 1 : 0
   vpc_id                  = aws_vpc.vpc.id
-  cidr_block              = var.master_subnet_cidr3
+  cidr_block              = var.control_plane_node_subnet_cidr3
   availability_zone       = var.availability_zone3
   map_public_ip_on_launch = true
-  depends_on              = [aws_internet_gateway.master]
+  depends_on              = [aws_internet_gateway.control_plane_node]
 
   tags = {
     "Name" : join("-", [var.network_tag_prefix, "public-subnet", var.availability_zone3])
   }
 }
 
-resource "aws_route_table" "master" {
+resource "aws_route_table" "control_plane_node" {
   vpc_id = aws_vpc.vpc.id
   route {
     cidr_block = "0.0.0.0/0"
-    gateway_id = aws_internet_gateway.master.id
+    gateway_id = aws_internet_gateway.control_plane_node.id
   }
 }
 
-resource "aws_route_table_association" "master1" {
-  subnet_id      = aws_subnet.master1.id
-  route_table_id = aws_route_table.master.id
+resource "aws_route_table_association" "control_plane_node1" {
+  subnet_id      = aws_subnet.control_plane_node1.id
+  route_table_id = aws_route_table.control_plane_node.id
 }
-resource "aws_route_table_association" "master2" {
+resource "aws_route_table_association" "control_plane_node2" {
   count          = var.az == "multi_zone" ? 1 : 0
-  subnet_id      = aws_subnet.master2[0].id
-  route_table_id = aws_route_table.master.id
+  subnet_id      = aws_subnet.control_plane_node2[0].id
+  route_table_id = aws_route_table.control_plane_node.id
 }
-resource "aws_route_table_association" "master3" {
+resource "aws_route_table_association" "control_plane_node3" {
   count          = var.az == "multi_zone" ? 1 : 0
-  subnet_id      = aws_subnet.master3[0].id
-  route_table_id = aws_route_table.master.id
+  subnet_id      = aws_subnet.control_plane_node3[0].id
+  route_table_id = aws_route_table.control_plane_node.id
 }
 
 resource "aws_eip" "eip1" {
@@ -96,21 +96,21 @@ resource "aws_eip" "eip3" {
 }
 resource "aws_nat_gateway" "nat1" {
   allocation_id = aws_eip.eip1.id
-  subnet_id     = aws_subnet.master1.id
+  subnet_id     = aws_subnet.control_plane_node1.id
 }
 resource "aws_nat_gateway" "nat2" {
   count         = var.az == "multi_zone" ? 1 : 0
   allocation_id = aws_eip.eip2[0].id
-  subnet_id     = aws_subnet.master2[0].id
+  subnet_id     = aws_subnet.control_plane_node2[0].id
 }
 resource "aws_nat_gateway" "nat3" {
   count         = var.az == "multi_zone" ? 1 : 0
   allocation_id = aws_eip.eip3[0].id
-  subnet_id     = aws_subnet.master3[0].id
+  subnet_id     = aws_subnet.control_plane_node3[0].id
 }
-resource "aws_subnet" "worker1" {
+resource "aws_subnet" "computenode1" {
   vpc_id            = aws_vpc.vpc.id
-  cidr_block        = var.worker_subnet_cidr1
+  cidr_block        = var.computenode_subnet_cidr1
   availability_zone = var.availability_zone1
   depends_on        = [aws_nat_gateway.nat1]
 
@@ -118,10 +118,10 @@ resource "aws_subnet" "worker1" {
     "Name" : join("-", [var.network_tag_prefix, "private-subnet", var.availability_zone1])
   }
 }
-resource "aws_subnet" "worker2" {
+resource "aws_subnet" "computenode2" {
   count             = var.az == "multi_zone" ? 1 : 0
   vpc_id            = aws_vpc.vpc.id
-  cidr_block        = var.worker_subnet_cidr2
+  cidr_block        = var.computenode_subnet_cidr2
   availability_zone = var.availability_zone2
   depends_on        = [aws_nat_gateway.nat2]
 
@@ -129,10 +129,10 @@ resource "aws_subnet" "worker2" {
     "Name" : join("-", [var.network_tag_prefix, "private-subnet", var.availability_zone2])
   }
 }
-resource "aws_subnet" "worker3" {
+resource "aws_subnet" "computenode3" {
   count             = var.az == "multi_zone" ? 1 : 0
   vpc_id            = aws_vpc.vpc.id
-  cidr_block        = var.worker_subnet_cidr3
+  cidr_block        = var.computenode_subnet_cidr3
   availability_zone = var.availability_zone3
   depends_on        = [aws_nat_gateway.nat3]
 
@@ -140,14 +140,14 @@ resource "aws_subnet" "worker3" {
     "Name" : join("-", [var.network_tag_prefix, "private-subnet", var.availability_zone3])
   }
 }
-resource "aws_route_table" "worker1" {
+resource "aws_route_table" "computenode1" {
   vpc_id = aws_vpc.vpc.id
   route {
     cidr_block = "0.0.0.0/0"
     gateway_id = aws_nat_gateway.nat1.id
   }
 }
-resource "aws_route_table" "worker2" {
+resource "aws_route_table" "computenode2" {
   count  = var.az == "multi_zone" ? 1 : 0
   vpc_id = aws_vpc.vpc.id
   route {
@@ -155,7 +155,7 @@ resource "aws_route_table" "worker2" {
     gateway_id = aws_nat_gateway.nat2[0].id
   }
 }
-resource "aws_route_table" "worker3" {
+resource "aws_route_table" "computenode3" {
   count  = var.az == "multi_zone" ? 1 : 0
   vpc_id = aws_vpc.vpc.id
   route {
@@ -164,18 +164,18 @@ resource "aws_route_table" "worker3" {
   }
 }
 resource "aws_route_table_association" "privateroute1" {
-  subnet_id      = aws_subnet.worker1.id
-  route_table_id = aws_route_table.worker1.id
+  subnet_id      = aws_subnet.computenode1.id
+  route_table_id = aws_route_table.computenode1.id
 }
 resource "aws_route_table_association" "privateroute2" {
   count          = var.az == "multi_zone" ? 1 : 0
-  subnet_id      = aws_subnet.worker2[0].id
-  route_table_id = aws_route_table.worker2[0].id
+  subnet_id      = aws_subnet.computenode2[0].id
+  route_table_id = aws_route_table.computenode2[0].id
 }
 resource "aws_route_table_association" "privateroute3" {
   count          = var.az == "multi_zone" ? 1 : 0
-  subnet_id      = aws_subnet.worker3[0].id
-  route_table_id = aws_route_table.worker3[0].id
+  subnet_id      = aws_subnet.computenode3[0].id
+  route_table_id = aws_route_table.computenode3[0].id
 }
 /*
 This security group allows intra-node communication on all ports with all

--- a/aws/terraform/network/outputs.tf
+++ b/aws/terraform/network/outputs.tf
@@ -2,26 +2,26 @@ output "vpcid" {
   value = aws_vpc.vpc.id
 }
 
-output "master_subnet1_id" {
-  value = aws_subnet.master1.id
+output "control_plane_node_subnet1_id" {
+  value = aws_subnet.control_plane_node1.id
 }
 
-output "master_subnet2_id" {
-  value = aws_subnet.master2[*].id
+output "control_plane_node_subnet2_id" {
+  value = aws_subnet.control_plane_node2[*].id
 }
 
-output "master_subnet3_id" {
-  value = aws_subnet.master3[*].id
+output "control_plane_node_subnet3_id" {
+  value = aws_subnet.control_plane_node3[*].id
 }
 
-output "worker_subnet1_id" {
-  value = aws_subnet.worker1.id
+output "computenode_subnet1_id" {
+  value = aws_subnet.computenode1.id
 }
 
-output "worker_subnet2_id" {
-  value = aws_subnet.worker2[*].id
+output "computenode_subnet2_id" {
+  value = aws_subnet.computenode2[*].id
 }
 
-output "worker_subnet3_id" {
-  value = aws_subnet.worker3[*].id
+output "computenode_subnet3_id" {
+  value = aws_subnet.computenode3[*].id
 }

--- a/aws/terraform/network/variables.tf
+++ b/aws/terraform/network/variables.tf
@@ -25,27 +25,27 @@ variable "vpc_cidr" {
   default     = "10.0.0.0/16"
 }
 
-variable "master_subnet_cidr1" {
+variable "control_plane_node_subnet_cidr1" {
   default = "10.0.0.0/20"
 }
 
-variable "master_subnet_cidr2" {
+variable "control_plane_node_subnet_cidr2" {
   default = "10.0.16.0/20"
 }
 
-variable "master_subnet_cidr3" {
+variable "control_plane_node_subnet_cidr3" {
   default = "10.0.32.0/20"
 }
 
-variable "worker_subnet_cidr1" {
+variable "computenode_subnet_cidr1" {
   default = "10.0.128.0/20"
 }
 
-variable "worker_subnet_cidr2" {
+variable "computenode_subnet_cidr2" {
   default = "10.0.144.0/20"
 }
 
-variable "worker_subnet_cidr3" {
+variable "computenode_subnet_cidr3" {
   default = "10.0.160.0/20"
 }
 

--- a/aws/terraform/ocp/main.tf
+++ b/aws/terraform/ocp/main.tf
@@ -1,6 +1,6 @@
 locals {
   classic_lb_timeout = 600
-  installer_workspace     = "${path.root}/aws/installer-files"
+  installer_workspace     = "${path.root}/installer-files"
   openshift_installer_url = "${var.openshift_installer_url}/stable-${var.openshift_version}/"
 }
 

--- a/aws/terraform/ocp/main.tf
+++ b/aws/terraform/ocp/main.tf
@@ -1,6 +1,6 @@
 locals {
   classic_lb_timeout = 600
-  installer_workspace     = "${path.root}/installer-files"
+  installer_workspace     = "${path.root}/aws/installer-files"
   openshift_installer_url = "${var.openshift_installer_url}/stable-${var.openshift_version}/"
 }
 

--- a/aws/terraform/ocp/variables.tf
+++ b/aws/terraform/ocp/variables.tf
@@ -32,52 +32,42 @@ variable "multi_zone" {
   type = bool
 }
 
-variable "worker_instance_type" {
+variable "computenode_instance_type" {
   type = string
   default = "m5.4xlarge"
 }
 
-variable "worker_instance_volume_iops" {
+variable "computenode_instance_volume_size" {
   type    = number
-  default = 2000
+  default = 150
 }
 
-variable "worker_instance_volume_size" {
-  type    = number
-  default = 300
-}
-
-variable "worker_instance_volume_type" {
+variable "computenode_instance_volume_type" {
   type    = string
-  default = "io1"
+  default = "gp2"
 }
 
-variable "worker_replica_count" {
+variable "computenode_replica_count" {
   type    = number
   default = 3
 }
 
-variable "master_instance_type" {
+variable "control_plane_node_instance_type" {
   type = string
   default = "m5.2xlarge"
 }
 
-variable "master_instance_volume_iops" {
+variable "control_plane_node_instance_volume_size" {
   type    = number
-  default = 4000
+  default = 150
 }
 
-variable "master_instance_volume_size" {
-  type    = number
-  default = 300
-}
-
-variable "master_instance_volume_type" {
+variable "control_plane_node_instance_volume_type" {
   type    = string
-  default = "io1"
+  default = "gp2"
 }
 
-variable "master_replica_count" {
+variable "control_plane_node_replica_count" {
   type    = number
   default = 3
 }
@@ -105,27 +95,27 @@ variable "region" {
   type = string
 }
 
-variable "master_subnet1_id" {
+variable "control_plane_node_subnet1_id" {
   type = string
 }
 
-variable "master_subnet2_id" {
+variable "control_plane_node_subnet2_id" {
   type = string
 }
 
-variable "master_subnet3_id" {
+variable "control_plane_node_subnet3_id" {
   type = string
 }
 
-variable "worker_subnet1_id" {
+variable "computenode_subnet1_id" {
   type = string
 }
 
-variable "worker_subnet2_id" {
+variable "computenode_subnet2_id" {
   type = string
 }
 
-variable "worker_subnet3_id" {
+variable "computenode_subnet3_id" {
   type = string
 }
 

--- a/aws/terraform/scripts/libs_aws/ec2_helper.py
+++ b/aws/terraform/scripts/libs_aws/ec2_helper.py
@@ -190,16 +190,16 @@ class EC2Helper():
 
         tf_config = {}
         tf_config['node_type'] = {}
-        tf_config['node_type']['master'] = {}
-        tf_config['node_type']['worker'] = {}
+        tf_config['node_type']['control_plane_node'] = {}
+        tf_config['node_type']['computenode'] = {}
 
         tf_config_json = AWSGenericHelper.get_terraform_config_json(terraform_var_file)
 
         # get specified instance types from terraform config
         tf_config['region'] = tf_config_json['variable']['region']['default']
         tf_config['storage_type'] = 'ocs' if tf_config_json['variable']['ocs']['default']['enable'] else 'portworx'
-        tf_config['node_type']['master']['instance_type'] = tf_config_json['variable']['master_instance_type']['default']
-        tf_config['node_type']['worker']['instance_type'] = tf_config_json['variable']['worker_instance_type']['default']
+        tf_config['node_type']['control_plane_node']['instance_type'] = tf_config_json['variable']['control_plane_node_instance_type']['default']
+        tf_config['node_type']['computenode']['instance_type'] = tf_config_json['variable']['computenode_instance_type']['default']
         if tf_config['storage_type'] == 'ocs':
             tf_config['node_type']['ocs'] = {}
             tf_config['node_type']['ocs']['instance_type'] = tf_config_json['variable']['ocs']['default']['dedicated_node_instance_type']
@@ -302,13 +302,13 @@ class EC2Helper():
         print("      - Specify a different region.")
         print("")
 
-    def calculate_num_service_worker_nodes(self,
-                                           worker_instance_type,
+    def calculate_num_service_computenode_nodes(self,
+                                           computenode_instance_type,
                                            tf_var_file):
 
         instance_type_vcpus = self.get_vcpus_per_instance_type()
-        worker_node_vcpus = instance_type_vcpus[worker_instance_type]
+        computenode_node_vcpus = instance_type_vcpus[computenode_instance_type]
         services_vcpus = AWSGenericHelper.get_services_vcpus(tf_var_file)
-        num_service_worker_nodes = abs(-services_vcpus // worker_node_vcpus)
+        num_service_computenode_nodes = abs(-services_vcpus // computenode_node_vcpus)
 
-        return num_service_worker_nodes
+        return num_service_computenode_nodes

--- a/aws/terraform/variables.tf
+++ b/aws/terraform/variables.tf
@@ -37,27 +37,27 @@ variable "vpc_cidr" {
   default     = "10.0.0.0/16"
 }
 
-variable "master_subnet_cidr1" {
+variable "control_plane_node_subnet_cidr1" {
   default = "10.0.0.0/20"
 }
 
-variable "master_subnet_cidr2" {
+variable "control_plane_node_subnet_cidr2" {
   default = "10.0.16.0/20"
 }
 
-variable "master_subnet_cidr3" {
+variable "control_plane_node_subnet_cidr3" {
   default = "10.0.32.0/20"
 }
 
-variable "worker_subnet_cidr1" {
+variable "computenode_subnet_cidr1" {
   default = "10.0.128.0/20"
 }
 
-variable "worker_subnet_cidr2" {
+variable "computenode_subnet_cidr2" {
   default = "10.0.144.0/20"
 }
 
-variable "worker_subnet_cidr3" {
+variable "computenode_subnet_cidr3" {
   default = "10.0.160.0/20"
 }
 
@@ -67,27 +67,27 @@ variable "worker_subnet_cidr3" {
 variable "vpc_id" {
   default = ""
 }
-variable "master_subnet1_id" {
+variable "control_plane_node_subnet1_id" {
   default = ""
 }
 
-variable "master_subnet2_id" {
+variable "control_plane_node_subnet2_id" {
   default = ""
 }
 
-variable "master_subnet3_id" {
+variable "control_plane_node_subnet3_id" {
   default = ""
 }
 
-variable "worker_subnet1_id" {
+variable "computenode_subnet1_id" {
   default = ""
 }
 
-variable "worker_subnet2_id" {
+variable "computenode_subnet2_id" {
   default = ""
 }
 
-variable "worker_subnet3_id" {
+variable "computenode_subnet3_id" {
   default = ""
 }
 #############################
@@ -97,7 +97,7 @@ variable "enable_permission_quota_check" {
 }
 
 variable "cluster_name" {
-  default = "my-ocp"
+  default = "zmodstack-ocp"
 }
 
 
@@ -155,52 +155,42 @@ variable "existing_openshift_token" {
 ##################################
 # New Openshift Cluster Variables
 ##################################
-variable "worker_instance_type" {
+variable "computenode_instance_type" {
   type    = string
   default = "m5.4xlarge"
 }
 
-variable "worker_instance_volume_iops" {
+variable "computenode_instance_volume_size" {
   type    = number
-  default = 2000
+  default = 150
 }
 
-variable "worker_instance_volume_size" {
-  type    = number
-  default = 300
-}
-
-variable "worker_instance_volume_type" {
+variable "computenode_instance_volume_type" {
   type    = string
-  default = "io1"
+  default = "gp2"
 }
 
-variable "worker_replica_count" {
+variable "computenode_replica_count" {
   type    = number
   default = 3
 }
 
-variable "master_instance_type" {
+variable "control_plane_node_instance_type" {
   type    = string
   default = "m5.2xlarge"
 }
 
-variable "master_instance_volume_iops" {
+variable "control_plane_node_instance_volume_size" {
   type    = number
-  default = 4000
+  default = 150
 }
 
-variable "master_instance_volume_size" {
-  type    = number
-  default = 300
-}
-
-variable "master_instance_volume_type" {
+variable "control_plane_node_instance_volume_type" {
   type    = string
-  default = "io1"
+  default = "gp2"
 }
 
-variable "master_replica_count" {
+variable "control_plane_node_replica_count" {
   type    = number
   default = 3
 }


### PR DESCRIPTION
This PR consists of the following changes

- Support for ocp 4.12
- naming changes for control plane node references
- additional capability to choose the type of boot node instance.
- added a script to gracefully shutdown the ocp cluster.
- sparse checkout strategy to clone aws repo as required.
- tagging the root ebs volume. 