### PR TITLE
fix to storageclass issue and renaming default storageclass

### DIFF
--- a/aws/terraform/ocp/main.tf
+++ b/aws/terraform/ocp/main.tf
@@ -182,19 +182,19 @@ EOF
   ]
 }
 
-resource "null_resource" "configure_gp3_default_storageclass" {
+resource "null_resource" "configure_gp3_immediate_storageclass" {
   triggers = {
     installer_workspace = local.installer_workspace
   }
   provisioner "local-exec" {
     command = <<EOF
-oc apply -f ${self.triggers.installer_workspace}/gp3_default.yaml --kubeconfig ${self.triggers.installer_workspace}/auth/kubeconfig
-oc patch storageclass gp2 -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}' --kubeconfig ${self.triggers.installer_workspace}/auth/kubeconfig
+oc patch storageclass $(oc get sc --kubeconfig ${self.triggers.installer_workspace}/auth/kubeconfig|grep "(default)"| awk '{print $1}') -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}' --kubeconfig ${self.triggers.installer_workspace}/auth/kubeconfig
+oc apply -f ${self.triggers.installer_workspace}/gp3_immediate.yaml --kubeconfig ${self.triggers.installer_workspace}/auth/kubeconfig
 EOF
   }
   depends_on = [
     null_resource.install_openshift,
-    local_file.gp3_default_yaml,
+    local_file.gp3_immediate_yaml,
   ]  
 } 
 

--- a/aws/terraform/ocp/templates.tf
+++ b/aws/terraform/ocp/templates.tf
@@ -261,12 +261,12 @@ spec:
 EOF
 }
 
-data "template_file" "gp3_default_storageclass" {
+data "template_file" "gp3_immediate_storageclass" {
   template =<<EOF
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-  name: gp3-default
+  name: gp3-immediate
   annotations:
     description: Default storage class
     storageclass.kubernetes.io/is-default-class: 'true'
@@ -280,9 +280,9 @@ volumeBindingMode: Immediate
 EOF
 }
 
-resource "local_file" "gp3_default_yaml" {
-  content  = data.template_file.gp3_default_storageclass.rendered
-  filename = "${local.installer_workspace}/gp3_default.yaml"
+resource "local_file" "gp3_immediate_yaml" {
+  content  = data.template_file.gp3_immediate_storageclass.rendered
+  filename = "${local.installer_workspace}/gp3_immediate.yaml"
 }
 
 data "template_file" "ibm_catalogsource" {


### PR DESCRIPTION

The storage classes and their names that spin up at the cluster creation were changed in ocp 4.12 onwards, the PR fixes the issue by dynamically picking the default storage class to undo and creates the custom 'gp3-immediate' storage class and sets it as the default storage class.