### PR TITLE
Refactored must-gather.yml for local/remote execution

### DIFF
--- a/azure/ansible/diagnostic/README.md
+++ b/azure/ansible/diagnostic/README.md
@@ -25,17 +25,14 @@ Running the ansible playbook from your local machine will connect your machine t
    cd zmodstack-deploy/azure/ansible/diagnostic
    ``` 
 
-2. Update `local.yml` file with the Azure Bootstrap VM IP address, SSH username and (optionally) RSA private key path
+2. Update `inventory/local.yml` file with the Azure Bootstrap VM IP address, SSH username and (optionally) RSA private key path, for example:
    ```yaml
    all:
      hosts:
        azure_vm:
          remote_host: true
-         # IP Address or Hostname
          ansible_host: 1.2.3.4
          ansible_user: vmadmin
-         # Uncomment and supply value if default SSH key is not configured for the ansible_host
-         # ansible_ssh_private_key_file: <path/to/local/ssh_key>
    ```
 
 3. Execute the Ansible playbook for collecting the must-gather data
@@ -43,7 +40,7 @@ Running the ansible playbook from your local machine will connect your machine t
    **Note**: Override variables as necessary, see [variable overrides](#variable-overrides).
 
    ```
-   ansible-playbook -i inventory/remote.yml must-gather.yml
+   ansible-playbook -i inventory/local.yml playbooks/must-gather.yml
    ```
 
 After following these steps, an archive file will be created in the specified `dir_out` directory, `~/Downloads` by default.

--- a/azure/ansible/diagnostic/README.md
+++ b/azure/ansible/diagnostic/README.md
@@ -1,40 +1,51 @@
-# Ansible Playbook
+# Diagnostic Playbooks
+The Ansible playbooks in this directory provide an automated way for retrieving diagnostic information from the IBM Z and Cloud Modernization Stack deployment in Azure.
 
-## Fetch OpenShift logs from Bootstrap VM
+Please [install Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html) on the machine you intend to run these playbooks from.
 
-1. Clone the GitHub repository to local system
-   ```
-   git clone --branch <BRANCH_NAME> https://github.com/IBM/zmodstack-deploy.git
+## Variable Overrides
+The following variables may be overridden when executing `ansible-playbook` using the `-e` [extra-vars argument](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_variables.html#defining-variables-at-runtime).
+
+| Variable | Default | Description |
+| ---------| --------| ------------|
+| `dir_mg` | `~/zmodstack/must-gather` | The base directory where all must-gather data will be copied into. A timestamped subdirectory will be created to store the copied data.
+| `dir_out`| `~/Downloads` | The output directory where the must-gather archive is written. |
+
+**Example usage**:
+```bash
+ansible-playbook -i inventory/remote.yml playbooks/must-gather.yml -e "dir_out=/some/other/dir"
+```
+
+## Run from Local Machine
+Running the ansible playbook from your local machine will connect your machine to the Azure Bootstrap VM over SSH, copy files locally on the VM, create an archive with all relevant data, and transmit the archive to your local machine.
+
+1. Clone the GitHub repository to local system and navigate to this folder
+   ```bash
+   git clone https://github.com/IBM/zmodstack-deploy.git
+   cd zmodstack-deploy/azure/ansible/diagnostic
    ``` 
 
-2. Change directory to the `inventory` folder
-   ```
-   cd zmodstack-deploy/azure/ansible/diagnostic/inventory
+2. Update `local.yml` file with the Azure Bootstrap VM IP address, SSH username and (optionally) RSA private key path
+   ```yaml
+   all:
+     hosts:
+       azure_vm:
+         remote_host: true
+         # IP Address or Hostname
+         ansible_host: 1.2.3.4
+         ansible_user: vmadmin
+         # Uncomment and supply value if default SSH key is not configured for the ansible_host
+         # ansible_ssh_private_key_file: <path/to/local/ssh_key>
    ```
 
-3. Update `hosts` file with BootStrap VM IP address, SSH Username and RSA Private Key path
-
-   <img width="672" alt="Screenshot 2023-08-24 at 8 21 34 PM" src="https://github.com/IBM/zmodstack-deploy/assets/50948780/6621bf32-d58e-4a09-8475-1737c72fd2fe">
-
-4. Change directory to the `vars` folder
-   ```
-   cd zmodstack-deploy/azure/ansible/diagnostic/playbooks/vars
-   ```
-
-5. Update `extra_vars.yml` file with the local system directory to capture the logs
+3. Execute the Ansible playbook for collecting the must-gather data
    
-   <img width="569" alt="Screenshot 2023-08-24 at 8 22 31 PM" src="https://github.com/IBM/zmodstack-deploy/assets/50948780/b673de4f-f962-478c-a1c7-f34cbaf389e5">
+   **Note**: Override variables as necessary, see [variable overrides](#variable-overrides).
 
-6. Change directory to the `playbooks` folder
    ```
-   cd zmodstack-deploy/azure/ansible/diagnostic/playbooks
-   ```
-
-7. Execute the Ansible playbook for capturing the logs
-   ```
-   ansible-playbook -i ../inventory/hosts must-gather.yml
+   ansible-playbook -i inventory/remote.yml must-gather.yml
    ```
 
-8. Logs will be copied to the local system directory given in step 5
+After following these steps, an archive file will be created in the specified `dir_out` directory, `~/Downloads` by default.
 
-9. Logs may contain sensitive information, so please check and remove those before sending across
+## Run from Azure Bootstrap VM

--- a/azure/ansible/diagnostic/README.md
+++ b/azure/ansible/diagnostic/README.md
@@ -32,12 +32,10 @@ Running the ansible playbook from your local machine will connect your machine t
        azure_vm:
          remote_host: true
          ansible_host: 1.2.3.4
-         ansible_user: vmadmin
+         ansible_user: azuser
    ```
 
 3. Execute the Ansible playbook for collecting the must-gather data
-   
-   **Note**: Override variables as necessary, see [variable overrides](#variable-overrides).
 
    ```
    ansible-playbook -i inventory/local.yml playbooks/must-gather.yml
@@ -46,3 +44,18 @@ Running the ansible playbook from your local machine will connect your machine t
 After following these steps, an archive file will be created in the specified `dir_out` directory, `~/Downloads` by default.
 
 ## Run from Azure Bootstrap VM
+Running the ansible playbook from the Azure Bootstrap VM will copy files locally on the VM, and create an archive with all relevant data. The archive file must be manually retrieved from the Azure VM for distribution.
+  
+1. Clone the GitHub repository to local system and navigate to this folder
+   ```bash
+   git clone https://github.com/IBM/zmodstack-deploy.git
+   cd zmodstack-deploy/azure/ansible/diagnostic
+   ``` 
+
+2. Execute the Ansible playbook for collecting the must-gather data
+
+   ```
+   ansible-playbook -i inventory/bootstrap.yml playbooks/must-gather.yml
+   ```
+
+After following these steps, an archive file will be created in the specified `dir_out` directory, `~/Downloads` by default.

--- a/azure/ansible/diagnostic/inventory/bootstrap.yml
+++ b/azure/ansible/diagnostic/inventory/bootstrap.yml
@@ -4,4 +4,4 @@ all:
       remote_host: false
       ansible_host: 127.0.0.1
       ansible_user: "{{ lookup('env', 'USER') }}"
-      connection: local
+      ansible_connection: local

--- a/azure/ansible/diagnostic/inventory/bootstrap.yml
+++ b/azure/ansible/diagnostic/inventory/bootstrap.yml
@@ -2,6 +2,6 @@ all:
   hosts:
     azure_vm:
       remote_host: false
-      ansible_host: localhost
+      ansible_host: 127.0.0.1
       ansible_user: "{{ lookup('env', 'USER') }}"
       connection: local

--- a/azure/ansible/diagnostic/inventory/bootstrap.yml
+++ b/azure/ansible/diagnostic/inventory/bootstrap.yml
@@ -1,0 +1,7 @@
+all:
+  hosts:
+    azure_vm:
+      remote_host: false
+      ansible_host: localhost
+      ansible_user: "{{ lookup('env', 'USER') }}"
+      connection: local

--- a/azure/ansible/diagnostic/inventory/hosts
+++ b/azure/ansible/diagnostic/inventory/hosts
@@ -1,6 +1,0 @@
-[azure_vm]
-<PUBLIC_IP_ADDRESS>
-
-[azure_vm:vars] 
-ansible_ssh_user=<USERNAME>
-ansible_ssh_private_key_file=<RSA_PRIVATE_KEY_FILE_PATH>

--- a/azure/ansible/diagnostic/inventory/local.yml
+++ b/azure/ansible/diagnostic/inventory/local.yml
@@ -1,0 +1,8 @@
+all:
+  hosts:
+    azure_vm:
+      remote_host: true
+      ansible_host: <hostname or ip address of azure VM>
+      ansible_user: <admin username set during deployment>
+      # Uncomment and supply value if default SSH key is not configured for the ansible_host
+      # ansible_ssh_private_key_file: <path/to/local/ssh_key>

--- a/azure/ansible/diagnostic/playbooks/must-gather.yml
+++ b/azure/ansible/diagnostic/playbooks/must-gather.yml
@@ -1,61 +1,56 @@
 ---
-- name: Fetch OpenShift Logs
+- name: Gather IBM Z and Cloud Modernization Stack deployment logs
   hosts: all
-  gather_facts: no
-  vars_files:
-    - vars/extra_vars.yml
+  gather_facts: true
   vars:
-    - date_time_stamp: "{{ lookup('pipe', 'date +%Y%m%d-%H%M') }}"  
+    - date_time_stamp: "{{ lookup('pipe', 'date +%Y%m%d%H%M') }}"
+    - dir_mg: "~/zmodstack/must-gather"
+    - dir_mgts: "{{ dir_mg }}/{{ date_time_stamp }}"
+    - dir_out: ~/Downloads
   tasks:
-  - name: Copy OpenShift Install log to home directory in Bootstrap VM
-    ansible.builtin.copy:
-      src: /mnt/openshift/openshiftfourx/.openshift_install.log
-      dest: ~/openshift_install.log
-      remote_src: yes
-    ignore_errors: true   
-  - name: Copy Handler log to home directory in Bootstrap VM
-    ansible.builtin.copy:
-      src: /var/log/azure/custom-script/handler.log
-      dest: ~/handler.log
-      remote_src: yes
-    ignore_errors: true   
-  - name: Copy Bootstrap script to home directory in Bootstrap VM
-    ansible.builtin.copy:
-      src: /var/lib/waagent/custom-script/download/0/bootstrap.sh
-      dest: "/home/{{ ansible_ssh_user }}/bootstrap.sh"
-      remote_src: yes
-    become: true  
-    ignore_errors: true  
-  - name: Copy stderr log to home directory in Bootstrap VM
-    ansible.builtin.copy:
-      src: /var/lib/waagent/custom-script/download/0/stderr
-      dest: "/home/{{ ansible_ssh_user }}/stderr"
-      remote_src: yes
-    become: true
-    ignore_errors: true   
-  - name: Copy stdout log to home directory in Bootstrap VM
-    ansible.builtin.copy:
-      src: /var/lib/waagent/custom-script/download/0/stdout
-      dest: "/home/{{ ansible_ssh_user }}/stdout"
-      remote_src: yes
-    become: true
-    ignore_errors: true                      
-  - name: Create an archive of the logs captured in Bootstrap VM
-    community.general.archive:
-      path:
-      - ~/openshift_install.log
-      - ~/handler.log
-      - ~/bootstrap.sh
-      - ~/stderr
-      - ~/stdout
-      dest: "~/zmodstack-deploy-logs-{{ date_time_stamp }}.tar.bz2"
-      format: bz2
-      remove: true
-  - name: Fetch log archive from Bootstrap VM to local system
-    ansible.builtin.fetch:
-      src: "~/zmodstack-deploy-logs-{{ date_time_stamp }}.tar.bz2"
-      dest: "{{ logs_dir }}/zmodstack-deploy-logs-{{ date_time_stamp }}.tar.bz2"
-      flat: yes
-  - name: Prints folder in local system where logs are copied
-    ansible.builtin.debug:
-      msg: "Logs are copied in {{ logs_dir }}. Logs may contain sensitive information, so please check and remove those before sending across."
+    - name: "Create must-gather directory: {{ dir_mgts }}"
+      ansible.builtin.file:
+        path: "{{ dir_mgts }}"
+        state: directory
+        mode: '750'
+    - name: Gather OpenShift install log
+      ansible.builtin.copy:
+        src: /mnt/openshift/openshiftfourx/.openshift_install.log
+        dest: "{{ dir_mgts }}/openshift_install.log"
+        remote_src: "{{ remote_host }}"
+        mode: '400'
+      ignore_errors: true
+    - name: Gather bootstrap script handler log
+      ansible.builtin.copy:
+        src: /var/log/azure/custom-script/handler.log
+        dest: "{{ dir_mgts }}/handler.log"
+        remote_src: "{{ remote_host }}"
+        mode: "400"
+      ignore_errors: true
+    - name: Gather bootstrap script files
+      ansible.builtin.copy:
+        src: "/var/lib/waagent/custom-script/download/0/"
+        dest: "{{ dir_mgts }}/."
+        remote_src: "{{ remote_host }}"
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+        mode: "750"
+      become: true
+    - name: Create an archive of the logs captured in Bootstrap VM
+      community.general.archive:
+        path:
+          - "{{ dir_mgts }}/*"
+        dest: "{{ dir_mgts }}/zmodstack-{{ date_time_stamp }}.tar.bz2"
+        format: bz2
+        mode: "400"
+    - name: Fetch log archive from Bootstrap VM to local system
+      ansible.builtin.fetch:
+        src: "{{ dir_mgts }}/zmodstack-{{ date_time_stamp }}.tar.bz2"
+        dest: "{{ dir_out }}/zmodstack-deploy-logs-{{ date_time_stamp }}.tar.bz2"
+        flat: true
+      when: remote_host
+    - name: Prints folder in local system where logs are copied
+      ansible.builtin.debug:
+        msg: >-
+          IBM Z and Cloud Modernization Stack must-gather data has been copied to {{ dir_out }}.
+          Logs may contain sensitive information, limit access and sanitize data as necessary.

--- a/azure/ansible/diagnostic/playbooks/must-gather.yml
+++ b/azure/ansible/diagnostic/playbooks/must-gather.yml
@@ -3,9 +3,10 @@
   hosts: all
   gather_facts: true
   vars:
-    - date_time_stamp: "{{ lookup('pipe', 'date +%Y%m%d%H%M') }}"
-    - dir_mg: "~/zmodstack/must-gather"
-    - dir_mgts: "{{ dir_mg }}/{{ date_time_stamp }}"
+    - timestamp: "{{ ansible_date_time.epoch }}"
+    # NOTE: Using ~ will cause steps that use 'become: true' to attempt to write to the root home dir
+    - dir_mg: "/home/{{ ansible_user }}/zmodstack/must-gather"
+    - dir_mgts: "{{ dir_mg }}/{{ ansible_date_time.epoch }}"
     - dir_out: ~/Downloads
   tasks:
     - name: "Create must-gather directory: {{ dir_mgts }}"
@@ -40,13 +41,13 @@
       community.general.archive:
         path:
           - "{{ dir_mgts }}/*"
-        dest: "{{ dir_mgts }}/zmodstack-{{ date_time_stamp }}.tar.bz2"
+        dest: "{{ dir_mgts }}/zmodstack-{{ timestamp }}.tar.bz2"
         format: bz2
         mode: "400"
     - name: Fetch log archive from Bootstrap VM to local system
       ansible.builtin.fetch:
-        src: "{{ dir_mgts }}/zmodstack-{{ date_time_stamp }}.tar.bz2"
-        dest: "{{ dir_out }}/zmodstack-deploy-logs-{{ date_time_stamp }}.tar.bz2"
+        src: "{{ dir_mgts }}/zmodstack-{{ timestamp }}.tar.bz2"
+        dest: "{{ dir_out }}/zmodstack-deploy-logs-{{ timestamp }}.tar.bz2"
         flat: true
       when: remote_host
     - name: Prints folder in local system where logs are copied

--- a/azure/ansible/diagnostic/playbooks/must-gather.yml
+++ b/azure/ansible/diagnostic/playbooks/must-gather.yml
@@ -8,6 +8,7 @@
     - dir_mg: "/home/{{ ansible_user }}/zmodstack/must-gather"
     - dir_mgts: "{{ dir_mg }}/{{ ansible_date_time.epoch }}"
     - dir_out: ~/Downloads
+    - file_archive: "zmodstack-{{ timestamp }}.tar.bz2"
   tasks:
     - name: "Create must-gather directory: {{ dir_mgts }}"
       ansible.builtin.file:
@@ -32,26 +33,26 @@
       ansible.builtin.copy:
         src: "/var/lib/waagent/custom-script/download/0/"
         dest: "{{ dir_mgts }}/."
-        remote_src: "{{ remote_host }}"
+        # Note: remote_src is purposefully hardcoded to true, see https://superuser.com/a/1805812/239541
+        remote_src: true
         owner: "{{ ansible_user }}"
         group: "{{ ansible_user }}"
         mode: "750"
       become: true
-    - name: Create an archive of the logs captured in Bootstrap VM
+    - name: Create an archive of all data gathered
       community.general.archive:
         path:
           - "{{ dir_mgts }}/*"
-        dest: "{{ dir_mgts }}/zmodstack-{{ timestamp }}.tar.bz2"
+        dest: "{{ dir_mgts }}/{{ file_archive }}"
         format: bz2
         mode: "400"
-    - name: Fetch log archive from Bootstrap VM to local system
+    - name: Fetch archive from Bootstrap VM to local system
       ansible.builtin.fetch:
-        src: "{{ dir_mgts }}/zmodstack-{{ timestamp }}.tar.bz2"
-        dest: "{{ dir_out }}/zmodstack-deploy-logs-{{ timestamp }}.tar.bz2"
+        src: "{{ dir_mgts }}/{{ file_archive }}"
+        dest: "{{ dir_out }}/{{ file_archive }}"
         flat: true
-      when: remote_host
     - name: Prints folder in local system where logs are copied
       ansible.builtin.debug:
         msg: >-
-          IBM Z and Cloud Modernization Stack must-gather data has been copied to {{ dir_out }}.
+          IBM Z and Cloud Modernization Stack must-gather data has been copied to {{ dir_out }}/{{ file_archive }}.
           Logs may contain sensitive information, limit access and sanitize data as necessary.

--- a/azure/ansible/diagnostic/playbooks/vars/extra_vars.yml
+++ b/azure/ansible/diagnostic/playbooks/vars/extra_vars.yml
@@ -1,2 +1,0 @@
----
-logs_dir: <LOCAL_DIRECTORY>


### PR DESCRIPTION
Enables the Azure `must-gather.yml` diagnostic playbook to be run from both a local environment as well as from the Azure Bootstrap VM.