### PR TITLE
Create Ansible playbook to validate OCP Cluster deployment in Azure

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -18,7 +18,9 @@ env:
   ARM_TEMPLATE_JSON: ./azure/marketplace/mainTemplate.json
   ARM_TEMPLATE_BICEP_TO_JSON: ./azure/marketplace/mainTemplateBicepToJson.json
   WORK_DIR: ./azure/marketplace
-  ANSIBLE_PLAYBOOK: ./azure/ansible/deployment/playbooks/run-provision.yml
+  ANSIBLE_PLAYBOOK_PROVISION: ./azure/ansible/deployment/playbooks/run-provision.yml
+  ANSIBLE_PLAYBOOK_VALIDATE: ./azure/ansible/deployment/playbooks/run-validate.yml
+  ANSIBLE_PLAYBOOK_DEPROVISION: ./azure/ansible/deployment/playbooks/run-deprovision.yml
 
 jobs: 
   deploy:
@@ -43,10 +45,12 @@ jobs:
       uses: azure/login@v1
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
-    - name: Ansible Playbook Runner
+    - name: Run Ansible Playbooks
       run: |
         ansible-galaxy collection install azure.azcollection --force
         pip install -r ~/.ansible/collections/ansible_collections/azure/azcollection/requirements-azure.txt
         pip install 'ansible[azure]'
-        ansible-playbook ${{ env.ANSIBLE_PLAYBOOK }}
+        ansible-playbook ${{ env.ANSIBLE_PLAYBOOK_PROVISION }}
+        ansible-playbook ${{ env.ANSIBLE_PLAYBOOK_VALIDATE }} -e OCP_PASSWORD=${{ secrets.OCP_PASSWORD }}
+        ansible-playbook ${{ env.ANSIBLE_PLAYBOOK_DEPROVISION }}
       shell: bash

--- a/azure/ansible/deployment/playbooks/run-deprovision.yml
+++ b/azure/ansible/deployment/playbooks/run-deprovision.yml
@@ -1,12 +1,12 @@
 ---
-- name: Destroy Azure Resources
+- name: Delete OCP Cluster
   hosts: localhost
 
   vars:
     RESOURCE_GROUP_DNS: z-mod-stack-rg
     DNS_ZONE: ibmzsw.com
     CLUSTER_NAME: z-mod-stack
-    CLUSTER_RESOURCE_GROUP_NAME: z-mod-stack-abc12-rg
+    CLUSTER_RESOURCE_GROUP_NAME: z-mod-stack-ocp-dev-rg
     RESOURCE_GROUP_NAME: z-mod-stack-dev-rg
 
   tasks:

--- a/azure/ansible/deployment/playbooks/run-provision.yml
+++ b/azure/ansible/deployment/playbooks/run-provision.yml
@@ -1,21 +1,27 @@
 ---
-- name: Deploy ARM Template
+- name: Create OCP Cluster
   hosts: localhost
 
   vars:
     RESOURCE_GROUP_NAME: z-mod-stack-dev-rg
     LOCATION: eastus
+    CLUSTER_RESOURCE_GROUP_NAME: z-mod-stack-ocp-dev-rg
     DEPLOYMENT_NAME: OCP-Cluster-Dev
     ARM_TEMPLATE: "{{ lookup('file', '../../../marketplace/mainTemplate.json') }}"
     ARM_PARAMETERS: "{{ (lookup('file', '../../../marketplace/mainParameters.json') | from_json).parameters }}"
 
   tasks:
-    - name: Create a Resource Group
+    - name: Create a Resource Group for Deployment
       azure.azcollection.azure_rm_resourcegroup:
         name: "{{ RESOURCE_GROUP_NAME }}"
         location: "{{ LOCATION }}"
 
-    - name: Create OCP Cluster
+    - name: Create a Resource Group for OCP Cluster
+      azure.azcollection.azure_rm_resourcegroup:
+        name: "{{ CLUSTER_RESOURCE_GROUP_NAME }}"
+        location: "{{ LOCATION }}"
+
+    - name: Deploy OCP Cluster
       azure.azcollection.azure_rm_deployment:
         name: "{{ DEPLOYMENT_NAME }}"
         resource_group_name: "{{ RESOURCE_GROUP_NAME }}"

--- a/azure/ansible/deployment/playbooks/run-validate.yml
+++ b/azure/ansible/deployment/playbooks/run-validate.yml
@@ -23,7 +23,6 @@
         "oc login --insecure-skip-tls-verify -u {{ OCP_USERNAME }} -p {{ OCP_PASSWORD }} --server=https://api.{{ CLUSTER_NAME }}.{{ DNS_ZONE }}:6443"
       register: cluster_login
       changed_when: cluster_login.rc != 0
-      ignore_errors: true
 
     - name: Openshift cluster API status
       ansible.builtin.debug:

--- a/azure/ansible/deployment/playbooks/run-validate.yml
+++ b/azure/ansible/deployment/playbooks/run-validate.yml
@@ -22,7 +22,7 @@
       ansible.builtin.command:
         "oc login --insecure-skip-tls-verify -u {{ OCP_USERNAME }} -p {{ OCP_PASSWORD }} --server=https://api.{{ CLUSTER_NAME }}.{{ DNS_ZONE }}:6443"
       register: cluster_login
-      changed_when: cluster_login.rc != 0
+      changed_when: cluster_login.rc == 0
 
     - name: Openshift cluster API status
       ansible.builtin.debug:
@@ -31,7 +31,7 @@
     - name: Check OpenShift cluster nodes
       ansible.builtin.command: oc get nodes
       register: cluster_nodes
-      changed_when: cluster_nodes.rc != 0
+      changed_when: cluster_nodes.rc == 0
 
     - name: Print Openshift cluster nodes
       ansible.builtin.debug:
@@ -40,7 +40,7 @@
     - name: Check OpenShift cluster operators
       ansible.builtin.command: oc get co
       register: cluster_operators
-      changed_when: cluster_operators.rc != 0
+      changed_when: cluster_operators.rc == 0
 
     - name: Print Openshift cluster operators
       ansible.builtin.debug:

--- a/azure/ansible/deployment/playbooks/run-validate.yml
+++ b/azure/ansible/deployment/playbooks/run-validate.yml
@@ -1,0 +1,48 @@
+---
+- name: Validate OCP Cluster
+  hosts: localhost
+
+  vars:
+    CLUSTER_NAME: z-mod-stack
+    DNS_ZONE: ibmzsw.com
+    OCP_USERNAME: ocpadmin
+
+  tasks:
+    - name: Check status of Openshift console
+      ansible.builtin.uri:
+        url: "https://console-openshift-console.apps.{{ CLUSTER_NAME }}.{{ DNS_ZONE }}/"
+        status_code: 200
+        validate_certs: false
+
+    - name: Openshift console status
+      ansible.builtin.debug:
+        msg: "Openshift console is up and running"
+
+    - name: Check login to Openshift cluster API
+      ansible.builtin.command:
+        "oc login --insecure-skip-tls-verify -u {{ OCP_USERNAME }} -p {{ OCP_PASSWORD }} --server=https://api.{{ CLUSTER_NAME }}.{{ DNS_ZONE }}:6443"
+      register: cluster_login
+      changed_when: cluster_login.rc != 0
+      ignore_errors: true
+
+    - name: Openshift cluster API status
+      ansible.builtin.debug:
+        var: cluster_login.stdout_lines
+
+    - name: Check OpenShift cluster nodes
+      ansible.builtin.command: oc get nodes
+      register: cluster_nodes
+      changed_when: cluster_nodes.rc != 0
+
+    - name: Print Openshift cluster nodes
+      ansible.builtin.debug:
+        var: cluster_nodes.stdout_lines
+
+    - name: Check OpenShift cluster operators
+      ansible.builtin.command: oc get co
+      register: cluster_operators
+      changed_when: cluster_operators.rc != 0
+
+    - name: Print Openshift cluster operators
+      ansible.builtin.debug:
+        var: cluster_operators.stdout_lines

--- a/azure/marketplace/mainParameters.json
+++ b/azure/marketplace/mainParameters.json
@@ -88,6 +88,9 @@
         "secretName": "openshiftPassword"
       }
     },
+    "clusterResourceGroupName": {
+      "value": "z-mod-stack-ocp-dev-rg"
+    },
     "apiKey": {
       "reference": {
         "keyVault": {


### PR DESCRIPTION
Create an Ansible playbook to validate OCP Cluster deployment in Azure. Execute the Ansible playbook in GitHub Action after the OCP Cluster is created and before it is deleted.

Related to the issue https://github.com/IBM/zmodstack-deploy/issues/40.