### PR TITLE
update wazi-aas create.yaml

### DIFF
--- a/ocp/ansible/ansible.cfg
+++ b/ocp/ansible/ansible.cfg
@@ -6,4 +6,4 @@ fact_caching_connection = .cache
 # stdout_callback = community.general.yaml
 
 [ssh_connection]
-pipelining = True
+pipelining = false

--- a/ocp/ansible/roles/ocp/tasks/main.yml
+++ b/ocp/ansible/roles/ocp/tasks/main.yml
@@ -20,11 +20,6 @@
   ignore_errors: true
   no_log: true
 
-- name: Inspect OCP Secret (Creds)
-  debug:
-    var: creds_secret
-    verbosity: 2
-
 - name: Inspect OCP Secret
   debug: 
     var: secret

--- a/ocp/ansible/roles/ocp/tasks/main.yml
+++ b/ocp/ansible/roles/ocp/tasks/main.yml
@@ -10,6 +10,21 @@
   # hide ansible logs since they will contain base64 encoded priv key
   no_log: true
 
+- name: "Check if OCP namespace contains cred"
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    name: "{{ creds_secret }}"
+    namespace: demo-iz
+  register: creds_secret
+  ignore_errors: true
+  no_log: true
+
+- name: Inspect OCP Secret (Creds)
+  debug:
+    var: creds_secret
+    verbosity: 2
+
 - name: Inspect OCP Secret
   debug: 
     var: secret
@@ -45,13 +60,19 @@
       # hide ansible logs since they will contain base64 encoded priv key
       no_log: true
 
-- name: Copy SSH key from OCP Secret
+- name: Copy SSH key and Creds from OCP Secret
   when: secret.resources | length == 1
   block:
     - name: Create directory in tekton workspace
       ansible.builtin.file:
         path: "{{ path_workspace }}/.ssh"
         state: directory
+        mode: '0755'
+
+    - name: Create directory in tekton workspace
+      ansible.builtin.file:
+        path: "{{ path_workspace }}/password"
+        state: touch
         mode: '0755'
 
     - name: Copy SSH private key
@@ -66,3 +87,10 @@
         content: "{{ secret.resources[0].data['ssh-pub-key'] | b64decode }}"
         dest: "{{ path_workspace }}/.ssh/{{ ssh_key_name }}.pub"
         mode: '0644'
+
+    - name: Copy SSH pass
+      when: creds_secret.resources | length == 1
+      ansible.builtin.copy:
+        content: "{{ creds_secret.resources[0].data['password'] | b64decode }}"
+        dest: "{{ path_workspace }}/password"
+        mode: '0400'

--- a/ocp/ansible/roles/ocp/tasks/main.yml
+++ b/ocp/ansible/roles/ocp/tasks/main.yml
@@ -15,7 +15,7 @@
     api_version: v1
     kind: Secret
     name: "{{ creds_secret }}"
-    namespace: demo-iz
+    namespace: ibm-zmodstack-deploy
   register: creds_secret
   ignore_errors: true
   no_log: true

--- a/ocp/ansible/roles/ocp/vars/main.yml
+++ b/ocp/ansible/roles/ocp/vars/main.yml
@@ -4,3 +4,4 @@ ssh_key_name: zmodstack-deploy
 path_ssh_key: "~/.ssh/{{ ssh_key_name }}"
 path_workspace: "/workspace/ws"
 ssh_secret: zmodstack-deploy-ssh
+creds_secret: vsi-creds

--- a/ocp/ansible/roles/wazi-aas/tasks/create.yml
+++ b/ocp/ansible/roles/wazi-aas/tasks/create.yml
@@ -1,4 +1,15 @@
 ---
+
+##TODO: Add sshpass to image. Only installing if on openshift. Comment out when running locally.
+- name: install sshpass
+#  when: ansible_distribution == 'openshift'
+  command: microdnf install sshpass -y
+
+##TODO: Add ssh-copy-id to image. Only installing if on openshift. Comment out when running locally.
+- name: install ssh-copy-id
+#  when: ansible_distribution == 'openshift'
+  command: microdnf install openssh-clients -y
+
 - name: Save zone as fact
   ansible.builtin.set_fact:
     # cacheable: true
@@ -59,6 +70,7 @@
 - name: Upload SSH Key
   when: ssh_key is undefined
   ibm.cloudcollection.ibm_is_ssh_key:
+    region: "{{ region }}"
     name: "{{ ssh_key_name }}"
     public_key: "{{ ssh_public_key.split()[:2]|join(' ') }}"
     id: "{{ ssh_key.id | default(omit) }}"
@@ -74,6 +86,8 @@
 - name: Retrieve image list
   when: image_dict is undefined
   ibm.cloudcollection.ibm_is_images_info:
+    resource_group: "{{ vpc.resource_group }}"
+    region: "{{ region }}"
   register: images_list
 
 - name: Set VM image name/id dictionary fact
@@ -163,16 +177,6 @@
     cacheable: true
     vsi: "{{ vsi_create_output.resource }}"
 
-# - name: Sleep for 15 seconds and continue with play
-#   ansible.builtin.wait_for:
-#     timeout: 15
-
-# - name: Stop the VSI to mount a data volume
-#   ibm.cloudcollection.ibm_is_instance_action:
-#     instance: "{{ vsi.id }}"
-#     action: stop
-#     # force_action: true
-
 - name: Attach Data Volume
   ibm.cloudcollection.ibm_is_instance_volume_attachment:
     instance: "{{ vsi.id }}"
@@ -195,6 +199,7 @@
 #     force_action: true
 
 - name: Restart the VSI
+  when: vsi_create_output.changed and vsi is defined
   ibm.cloudcollection.ibm_is_instance_action:
     instance: "{{ vsi.id }}"
     action: start
@@ -226,16 +231,37 @@
   copy: content="{{ fip.address }}" dest="{{ path_workspace }}/ip-address.txt"
 
 
-# - name: Add VSI to Ansible inventory
-#   when: fip.address not in groups['new_vsi'] | default([])
-#   ansible.builtin.add_host:
-#     name: "{{ fip.address }}"
-#     ansible_user: "{{ instance.username | default('root') }}"
-#     groups: new_vsi
-#     ansible_ssh_extra_args: "-o StrictHostKeyChecking=no"
-#     ansible_interpreter_python_fallback: "{{ instance.python_interpreters | default(omit) }}"
+- name: Add VSI to Ansible inventory
+  when: fip.address not in groups['new_vsi'] | default([])
+  ansible.builtin.add_host:
+     name: "{{ fip.address }}"
+     ansible_user: "{{ instance.username | default('root') }}"
+     ansible_password: "{{ssh_password}}"
+     groups: new_vsi
+     ansible_ssh_extra_args: "-o StrictHostKeyChecking=no"
+     ansible_interpreter_python_fallback: "{{ instance.python_interpreters | default(omit) }}"
 
-# TODO - Check once zvsi has ssh enabled by default
-# - name: Wait for VSI to become reachable over SSH
-#   ansible.builtin.wait_for_connection:
-#   delegate_to: "{{ fip.address }}"
+- name: Wait for VSI to become reachable over SSH
+  delegate_to: "{{ fip.address }}"
+  ansible.builtin.wait_for_connection:
+    connect_timeout: 60
+    delay: 3
+    timeout: 500
+
+- name: Copy SSH public key to remote host
+  command: >
+    sshpass -f {{ ssh_password_file }}
+    ssh-copy-id
+    -i {{ ssh_public_path }}
+    -o StrictHostKeyChecking=no
+    {{ instance.username }}@{{ fip.address }}
+#
+##- name: zos copy ssh key
+##  delegate_to: "{{ fip.address }}"
+##  ibm.ibm_zos_core.zos_copy:
+##    src: "~/.ssh/zmodstack-deploy.pub"
+##    dest: /u/ibmuser/.ssh
+##    mode: '0644'
+##    encoding:
+##      from: 'ISO8859-1'
+##      to: 'IBM-1047'

--- a/ocp/ansible/roles/wazi-aas/vars/main.yml
+++ b/ocp/ansible/roles/wazi-aas/vars/main.yml
@@ -16,6 +16,11 @@ instance:
     - /usr/lpp/IBM/cyp/v3r8/pyz/bin/python3
 ssh_key_name: zmodstack-deploy
 ssh_public_key: "{{lookup('file', '~/.ssh/zmodstack-deploy.pub') }}"
+ssh_public_path: "~/.ssh/zmodstack-deploy.pub"
+# Need to point to a file locally with the password if running locally
+ssh_password: "{{lookup('file', '/workspace/ws/password') }}"
+# Need to point to a file locally with the password if running locally
+ssh_password_file: "/workspace/ws/password"
 # region: eu-gb
 region: us-east
 zone: "{{region}}-2"
@@ -30,5 +35,6 @@ data_volume_capacity: 250  # Set the desired storage size in GB
 data_volume_snapshot: "{{ instance.image }}"
 delete_volume_on_instance_delete: true
 data_volume_iops: 1000
-
+num_subnets: 3
+# Need to point to a file locally if running locally
 path_workspace: "/workspace/ws"


### PR DESCRIPTION
## Description

- Updated the `ocp` and `wazi-aas` ansible roles. 

### Summary


#### Files Modified

1. **`ocp/ansible/ansible.cfg`**
   - Modified `pipelining` in SSH connection from `True` to `False`. It errors on the wait for ssh task with a python module error. Changed it to false based on what some folks on slack were saying worked as a workaround

2. **`ocp/ansible/roles/ocp/tasks/main.yml`**
   - Added tasks for inspecting and copying credentials from the OCP namespace.

4. **`ocp/ansible/roles/wazi-aas/tasks/create.yml`**
   - Introduced tasks for installing `sshpass` and `openssh-clients` based on the OpenShift distribution.
   - Updated tasks for uploading SSH keys.
   - Updated tasks that restart the virtual server instance (VSI) to be conditional based on change.
   - Modified tasks for adding VSI to Ansible inventory and waiting for VSI to become reachable over SSH.

5. **`ocp/ansible/roles/wazi-aas/vars/main.yml`**
   - Adjusted `ssh_public_key` and `ssh_password` variables.
   - Modified `region` variable to 'us-east'.